### PR TITLE
[deps] Add and import Buffer, to avoid relying on a global definition.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1199,8 +1199,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1464,7 +1463,6 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
       "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -3659,8 +3657,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "repository": "charpeni/whatwg-url",
   "dependencies": {
+    "buffer": "^5.4.3",
     "webidl-conversions": "^5.0.0"
   },
   "devDependencies": {

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -1,4 +1,5 @@
 "use strict";
+const { Buffer } = require("buffer/");
 const punycode = require("punycode");
 
 const infra = require("./infra");

--- a/src/urlencoded.js
+++ b/src/urlencoded.js
@@ -1,4 +1,6 @@
 "use strict";
+const { Buffer } = require("buffer/");
+
 const { isASCIIHex } = require("./infra");
 
 function p(char) {


### PR DESCRIPTION
This makes sense in a React Native app, where it's normal for Buffer
not to be defined.

One can always define it globally themselves, as is done in
https://github.com/charpeni/react-native-url-polyfill/blob/master/index.js#L18.
(The version of 'buffer' added in this commit matches the 'buffer'
version in the latest master of that repository as of writing this.)
But it's nice, if feasible, to give the option to avoid changing
global variables.

The trailing slash was added as prompted in the Usage section of the
'buffer' page on NPM [1].

To test that this works, I ran `npm run build` in the project
directory. Then, in my own React Native project's `package.json`, I
put '../whatwg-url' (the path to my local, built copy with this
change) for `whatwg-url-without-unicode` in my dependencies. My
project doesn't have anything assigned to the Buffer global
variable, nor does it directly depend on 'buffer' from NPM. It
worked as expected, without any `ReferenceError`s about Buffer not
being defined.

[1]: https://www.npmjs.com/package/buffer#usage